### PR TITLE
chore: add more examples for query parameters number type and string type

### DIFF
--- a/examples/parameters/parameters.oas.yml
+++ b/examples/parameters/parameters.oas.yml
@@ -72,6 +72,36 @@ paths:
       responses:
         "200":
           description: successful operation
+  /query/style/form/single/string:
+    get:
+      summary: Query style form with single value string parameter
+      description: Query style form with single value string parameter
+      operationId: getQueryStyleFormSingleValueString
+      parameters:
+      - in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: successful operation
+  /query/style/form/single/number:
+    get:
+      summary: Query style form with single value number parameter
+      description: Query style form with single value number parameter
+      operationId: getQueryStyleFormSingleValueNumber
+      parameters:
+      - in: query
+        name: id
+        required: true
+        schema:
+          type: number
+      responses:
+        "200":
+          description: successful operation
+        "400":
+          description: Invalid input
   /query/style/form/explode/true:
     get:
       summary: Query style form with explode true

--- a/examples/parameters/parameters.pact.json
+++ b/examples/parameters/parameters.pact.json
@@ -158,6 +158,89 @@
       "response": {
         "status": 200
       }
+    },
+    {
+      "description": "a request using form style with singe value query parameter string type",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/string",
+        "query": "name=fred"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "a request using form style with singe value query parameter string type (with pact query object)",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/string",
+        "query": {
+          "name": "fred"
+        },
+        "response": {
+          "status": 200
+        }
+      }
+    },
+    {
+      "description": "a request using form style with singe value query parameter number type",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/number",
+        "query": "id=1"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "a request using form style with singe value query parameter number type (with pact query object)",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/number",
+        "query": {
+          "id": 1
+        }
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "an invalid request using form style with singe value query parameter number type",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/number",
+        "query": "id=one"
+      },
+      "response": {
+        "status": 400
+      }
+    },
+    {
+      "description": "an invalid request using form style with singe value query parameter number type (with pact query object)",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/number",
+        "query": {
+          "id": "one"
+        }
+      },
+      "response": {
+        "status": 400
+      }
+    },
+    {
+      "description": "an invalid request using alphanumeric form style with singe value query parameter number type",
+      "request": {
+        "method": "GET",
+        "path": "/query/style/form/single/number",
+        "query": "id=1a"
+      },
+      "response": {
+        "status": 400
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
alpha numberics or non number strings are not coerce-able to numbers but actual numbers like "1" or "99" are coerced into numbers 1 or 99 respectively